### PR TITLE
Fix fomula 7) as before only maxlen/2 timesteps were considered

### DIFF
--- a/MFN_imdb.py
+++ b/MFN_imdb.py
@@ -155,6 +155,9 @@ c_s_3 = concatenate([c_s_2,c_s])
 
 t = Lambda(lambda x: x[:, ::2])(c_s_3)
 t_1 = Lambda(lambda x: x[:, 1::2])(c_s_3)
+
+t = Lambda(lambda x: x[:, :(maxlen-1)])(c_s_3)
+t_1 = Lambda(lambda x: x[:, 1:])(c_s_3)
 c = concatenate([t, t_1])
 
 

--- a/MFN_imdb.py
+++ b/MFN_imdb.py
@@ -153,9 +153,6 @@ h = Lambda(lambda x: x[:,:,emb:])(ch)#公式 6
 c_s_2 = concatenate([c_s,c_s])
 c_s_3 = concatenate([c_s_2,c_s])
 
-t = Lambda(lambda x: x[:, ::2])(c_s_3)
-t_1 = Lambda(lambda x: x[:, 1::2])(c_s_3)
-
 t = Lambda(lambda x: x[:, :(maxlen-1)])(c_s_3)
 t_1 = Lambda(lambda x: x[:, 1:])(c_s_3)
 c = concatenate([t, t_1])


### PR DESCRIPTION
On previous version, you are missing some elements of the sequence (ie taking into account only ([1-2,3-4,5-6,...]) , but in the original version of the paper, the sequence need to be ([1-2,2-3,3-4,...])